### PR TITLE
Fix compilation with GCC 11 for Ubuntu 22 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ find_package(Threads REQUIRED)
 
 add_executable(ptu ${ptu_main_source})
 target_link_libraries(ptu PRIVATE ptu_lib PRIVATE Threads::Threads)
+target_link_options(ptu PRIVATE "LINKER:--allow-multiple-definition")
 
 ################################################################################
 # ARCHITECTURE CHECKS / DEFS


### PR DESCRIPTION
Add allow-multiple-definition, which is disabled by default in GCC 11.

This is required for https://github.com/depaul-dice/sciunit/issues/28