### PR TITLE
Fix linker errors when running `cmake && make`

### DIFF
--- a/readelf-mini/dwarf.c
+++ b/readelf-mini/dwarf.c
@@ -61,7 +61,7 @@ int do_debug_frames_interp;
 int do_debug_macinfo;
 int do_debug_str;
 int do_debug_loc;
-int do_wide;
+int dwarf_do_wide; // this symbol conflicts with readelf-mini/readelf-mini.c do_wide
 
 /* Values for do_debug_lines.  */
 #define FLAG_DEBUG_LINES_RAW	 1
@@ -2603,7 +2603,7 @@ display_debug_lines_decoded (struct dwarf_section *section,
             }
           else
             {
-              if (do_wide || strlen ((char *) directory_table[0]) < 76)
+              if (dwarf_do_wide || strlen ((char *) directory_table[0]) < 76)
                 {
                   printf (_("CU: %s/%s:\n"), directory_table[0],
                           file_table[0].name);
@@ -2790,7 +2790,7 @@ display_debug_lines_decoded (struct dwarf_section *section,
               char *newFileName = NULL;
               size_t fileNameLength = strlen (fileName);
 
-              if ((fileNameLength > MAX_FILENAME_LENGTH) && (!do_wide))
+              if ((fileNameLength > MAX_FILENAME_LENGTH) && (!dwarf_do_wide))
                 {
                   newFileName = (char *) xmalloc (MAX_FILENAME_LENGTH + 1);
                   /* Truncate file name */
@@ -2804,7 +2804,7 @@ display_debug_lines_decoded (struct dwarf_section *section,
                   strncpy (newFileName, fileName, fileNameLength + 1);
                 }
 
-              if (!do_wide || (fileNameLength <= MAX_FILENAME_LENGTH))
+              if (!dwarf_do_wide || (fileNameLength <= MAX_FILENAME_LENGTH))
                 {
                   printf (_("%-35s  %11d  %#18lx\n"), newFileName,
                           state_machine_regs.line, state_machine_regs.address);

--- a/strace-4.6/defs.h
+++ b/strace-4.6/defs.h
@@ -34,10 +34,10 @@
 #define CDE_OPTIONS_VERSION_NUM "# cde.options v1"
 //#define CDE_ROOT_NAME "cde-root"
 #define CDE_ROOT_NAME_DEFAULT "cde-root"
-char* CDE_ROOT_NAME;
+extern char* CDE_ROOT_NAME; // declared here; defined in strace-4.6/cde.c
 // pgbovine - these are both ABSOLUTE paths
-char* CDE_PACKAGE_DIR;
-char* CDE_ROOT_DIR;
+extern char* CDE_PACKAGE_DIR; // declared here; defined in strace-4.6/cde.c
+extern char* CDE_ROOT_DIR; // declared here; defined in strace-4.6/cde.c
 
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
I got the following linker errors, which this commit fixes:

```
ld: libptu_lib.a(cde.c.o):strace-4.6/defs.h:40: multiple definition of `CDE_ROOT_DIR'; strace-4.6/strace.c.o:/build/source/strace-4.6/defs.h:40: first defined here
ld: libptu_lib.a(cde.c.o):strace-4.6/defs.h:37: multiple definition of `CDE_ROOT_NAME'; strace-4.6/strace.c.o:/build/source/strace-4.6/defs.h:37: first defined here
ld: libptu_lib.a(cde.c.o):strace-4.6/defs.h:39: multiple definition of `CDE_PACKAGE_DIR'; strace-4.6/strace.c.o:/build/source/strace-4.6/defs.h:39: first defined here
ld: libptu_lib.a(dwarf.c.o):readelf-mini/dwarf.c:64: multiple definition of `do_wide'; libptu_lib.a(readelf-mini.c.o):readelf-mini/readelf-mini.c:168: first defined here
```

Are you using any special commands to compile this?