### PR TITLE
Fix copy_pycache_python_source() method call location 

### DIFF
--- a/strace-4.6/okapi.c
+++ b/strace-4.6/okapi.c
@@ -535,6 +535,9 @@ void create_mirror_file(char* filename_abspath, char* src_prefix, char* dst_pref
       // create all the directories leading up to it, to make sure file
       // copying/hard-linking will later succeed
       create_mirror_dirs(filename_abspath, src_prefix, dst_prefix, 1);
+     
+      // copy original python source based on pycache file
+      copy_pycache_python_source(filename_abspath, src_prefix, dst_prefix);
 
       // 1.) try a hard link for efficiency
       // 2.) if that fails, then do a straight-up copy,
@@ -542,9 +545,9 @@ void create_mirror_file(char* filename_abspath, char* src_prefix, char* dst_pref
       //
       // EEXIST means the file already exists, which isn't
       // really a hard link failure ...
+
       if ((link(src_path, dst_path) != 0) && (errno != EEXIST)) {
         copy_file(src_path, dst_path, 0);
-        copy_pycache_python_source(filename_abspath, src_prefix, dst_prefix);
       }
     }
     else if (S_ISDIR(src_path_stat.st_mode)) { // directory or symlink to directory


### PR DESCRIPTION
Issue:
During the creation of the cde-root/ directory, the method copy_pycache_python_source() failed to execute as intended. This method is responsible for copying source Python files based on .pyc cache files. The problem arose because its invocation was contingent upon a condition ((link(src_path, dst_path) != 0) && (errno != EEXIST)) that never evaluated to true. This condition checks for errors during the creation of hard links for files, and because it did not trigger any errors, the copy_pycache_python_source() method was skipped.

Fix:
To ensure that copy_pycache_python_source() executes correctly every time, we have relocated its call to a new location where it is guaranteed to be invoked during the process of copying or linking files in the cde-root/ directory.

