### PR TITLE
Attach to running pid

### DIFF
--- a/strace-4.6/okapi.c
+++ b/strace-4.6/okapi.c
@@ -436,6 +436,17 @@ char* format(const char *format, ...) {
   return ptr;
 }
 
+int endswith(const char *path, const char *ext) {
+	int len_p = strlen(path);
+	int len_e = strlen(ext);
+
+	if (len_p < len_e) {
+		return 0;
+	}
+
+	return strcmp((path + len_p - len_e), ext);
+}
+
 /* If file is python cache file, copy its Python source file also */
 void copy_pycache_python_source(char* filename_abspath, char* src_prefix, char* dst_prefix) {
 

--- a/strace-4.6/strace.c
+++ b/strace-4.6/strace.c
@@ -129,7 +129,7 @@ unsigned int ptrace_setoptions = 0;
 int dtime = 0, xflag = 0, qflag = 1; // pgbovine - turn on quiet mode (-q) by
                                      // default to shut up terminal line noise
 cflag_t cflag = CFLAG_NONE;
-static int iflag = 0, interactive = 0, pflag_seen = 0, rflag = 0, tflag = 0;
+static int iflag = 0, interactive = 0, pflag_seen = 0, rflag = 0, tflag = 0, pid_to_attach = -1;
 /*
  * daemonized_tracer supports -D option.
  * With this option, strace forks twice.
@@ -2684,7 +2684,7 @@ int main (int argc, char *argv[]) {
 #ifndef USE_PROCFS
 		"D"
 #endif
-		"a:e:o:O:u:E:i:p:P:I:")) != EOF) {
+		"A:a:e:o:O:u:E:i:p:P:I:")) != EOF) {
 		switch (c) {
 		case 'c':
       // pgbovine - hijack for -c option
@@ -2855,6 +2855,9 @@ int main (int argc, char *argv[]) {
 		case 'w':
 			/*CDE_network_content_mode = 1;*/
 			break;
+		case 'A':
+			pid_to_attach = atoi(optarg);
+			break;
 		default:
 			usage(stderr, 1);
 			break;
@@ -2888,7 +2891,7 @@ int main (int argc, char *argv[]) {
 	qualify("verbose=all");
 	qualify("signal=all");
 
-	if ((optind == argc) == !pflag_seen)
+	if (((optind == argc) == !pflag_seen) && pid_to_attach < 0)
 		usage(stderr, 1);
 
 	if (pflag_seen && daemonized_tracer) {
@@ -2983,6 +2986,34 @@ int main (int argc, char *argv[]) {
 	   0			1		1		1
 	 */
 
+
+	if (pid_to_attach > 0) {
+		// If attaching to a pid, then pretend that the executable name
+		// was given in argv. We construct new argvs accordingly.
+		// so that the rest of code does not change.
+		
+		char pid_symlink_name[MAXPATHLEN];
+		char pid_symlink_exe[MAXPATHLEN];
+		int pid_symlink_status;
+
+		snprintf(pid_symlink_exe, MAXPATHLEN, "/proc/%d/exe", pid_to_attach);
+		pid_symlink_status = readlink(pid_symlink_exe, pid_symlink_name, MAXPATHLEN);
+		if (pid_symlink_status < 0) {
+			perror("strace: exec readlink");
+			exit(1);
+		}
+		perror(pid_symlink_name);
+
+		char **new_argv = malloc(2 * sizeof(char *));
+		new_argv[0] = malloc(MAXPATHLEN * sizeof(char));
+		new_argv[1] = malloc(MAXPATHLEN * sizeof(char));
+
+		strncpy(new_argv[0], argv[0], MAXPATHLEN);
+		strncpy(new_argv[1], pid_symlink_name, MAXPATHLEN);
+
+		argv = new_argv;
+		optind = 1;
+	}
 
 	// pgbovine - do all CDE initialization here after command-line options
 	// have been processed (argv[optind] is the name of the target program)

--- a/strace-4.6/strace.c
+++ b/strace-4.6/strace.c
@@ -2231,13 +2231,13 @@ trace()
 
 		if (pid_to_attach > 0) {
 			if (stop_tracing_from_signal) {
-				return 0;
+				break;
 			}
 
 			int status = kill(pid_to_attach, 0);
 			if (status != 0) {
 				/* if we could not send checkup signal, process is gone */
-				return 0;
+				break;
 			}
 		} else if (pid == -1) {
 			switch (wait_errno) {

--- a/strace-4.6/strace.c
+++ b/strace-4.6/strace.c
@@ -2210,7 +2210,13 @@ trace()
 		if (interactive)
 			sigprocmask(SIG_BLOCK, &blocked_set, NULL);
 
-		if (pid == -1) {
+		if (pid_to_attach > 0) {
+			int status = kill(pid_to_attach, 0);
+			if (status != 0) {
+				/* if we could not send checkup signal, process is gone */
+				return 0;
+			}
+		} else if (pid == -1) {
 			switch (wait_errno) {
 			case EINTR:
 				continue;

--- a/strace-4.6/strace.c
+++ b/strace-4.6/strace.c
@@ -129,7 +129,7 @@ unsigned int ptrace_setoptions = 0;
 int dtime = 0, xflag = 0, qflag = 1; // pgbovine - turn on quiet mode (-q) by
                                      // default to shut up terminal line noise
 cflag_t cflag = CFLAG_NONE;
-static int iflag = 0, interactive = 0, pflag_seen = 0, rflag = 0, tflag = 0, pid_to_attach = -1;
+static int iflag = 0, interactive = 0, pflag_seen = 0, rflag = 0, tflag = 0, pid_to_attach = -1, stop_tracing_from_signal = 0;
 /*
  * daemonized_tracer supports -D option.
  * With this option, strace forks twice.
@@ -1570,7 +1570,11 @@ cleanup()
 			detach(tcp, 0);
 		else {
 			kill(tcp->pid, SIGCONT);
-			kill(tcp->pid, SIGTERM);
+
+			if (pid_to_attach < 0) {
+				// don't kill the traced processed unless we created them
+				kill(tcp->pid, SIGTERM);
+			}
 		}
 	}
 	if (cflag)
@@ -2211,6 +2215,10 @@ trace()
 			sigprocmask(SIG_BLOCK, &blocked_set, NULL);
 
 		if (pid_to_attach > 0) {
+			if (stop_tracing_from_signal) {
+				return 0;
+			}
+
 			int status = kill(pid_to_attach, 0);
 			if (status != 0) {
 				/* if we could not send checkup signal, process is gone */
@@ -2636,6 +2644,10 @@ mp_ioctl(int fd, int cmd, void *arg, int size)
 
 #endif
 
+static void stop_tracing_sig_handler(int signo) {
+	stop_tracing_from_signal = 1;
+}
+
 /*******************************************************************************
  * PUBLIC INTERFACE
  ******************************************************************************/
@@ -3050,7 +3062,14 @@ int main (int argc, char *argv[]) {
 
 	sigemptyset(&empty_set);
 	sigemptyset(&blocked_set);
-	sa.sa_handler = SIG_IGN;
+
+	if (pid_to_attach > 0) {
+		// If attaching to an external pid, stop tracing when receiving a signal
+		sa.sa_handler = stop_tracing_sig_handler;
+	}
+	else {
+		sa.sa_handler = SIG_IGN;
+	}
 	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = 0;
 	sigaction(SIGTTOU, &sa, NULL);
@@ -3068,10 +3087,11 @@ int main (int argc, char *argv[]) {
 #endif /* SUNOS4 */
 	}
 	sigaction(SIGHUP, &sa, NULL);
+	sigaction(SIGPIPE, &sa, NULL);
 	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGQUIT, &sa, NULL);
-	sigaction(SIGPIPE, &sa, NULL);
 	sigaction(SIGTERM, &sa, NULL);
+
 #ifdef USE_PROCFS
 	sa.sa_handler = reaper;
 	sigaction(SIGCHLD, &sa, NULL);

--- a/strace-4.6/strace.c
+++ b/strace-4.6/strace.c
@@ -532,7 +532,7 @@ startup_attach(void)
 }
 
 static void
-startup_child (char **argv)
+startup_child (char **argv, int pid_to_attach)
 {
 	struct stat statbuf;
 	const char *filename;
@@ -622,12 +622,18 @@ startup_child (char **argv)
 			progname, filename, path_to_search);
 		exit(1);
 	}
-	strace_child = pid = fork();
-	if (pid < 0) {
-		perror("strace: fork");
-		cleanup();
-		exit(1);
+
+	if (pid_to_attach > 0) {
+		strace_child = pid = pid_to_attach;
+	} else {
+		strace_child = pid = fork();
+		if (pid < 0) {
+			perror("strace: fork");
+			cleanup();
+			exit(1);
+		}
 	}
+
 	if ((pid != 0 && daemonized_tracer) /* parent: to become a traced process */
 	 || (pid == 0 && !daemonized_tracer) /* child: to become a traced process */
 	) {
@@ -3034,7 +3040,7 @@ int main (int argc, char *argv[]) {
 	   Also we do not need to be protected by them as during interruption
 	   in the STARTUP_CHILD mode we kill the spawned process anyway.  */
 	if (!pflag_seen)
-		startup_child(&argv[optind]);
+		startup_child(&argv[optind], pid_to_attach);
 
 	sigemptyset(&empty_set);
 	sigemptyset(&blocked_set);

--- a/strace-4.6/strace.c
+++ b/strace-4.6/strace.c
@@ -636,8 +636,11 @@ startup_child (char **argv, int pid_to_attach)
 
 	if ((pid != 0 && daemonized_tracer) /* parent: to become a traced process */
 	 || (pid == 0 && !daemonized_tracer) /* child: to become a traced process */
+	 || (pid == pid_to_attach) /* external to become a traced process */
 	) {
-		pid = getpid();
+		if (pid == 0) {
+			pid = getpid();
+		}
 #ifdef USE_PROCFS
 		if (outf != stderr) close (fileno (outf));
 #ifdef MIPS
@@ -657,9 +660,16 @@ startup_child (char **argv, int pid_to_attach)
 			close(fileno (outf));
 
 		if (!daemonized_tracer) {
-			if (ptrace(PTRACE_TRACEME, 0, (char *) 1, 0) < 0) {
-				perror("strace: ptrace(PTRACE_TRACEME, ...)");
-				exit(1);
+			if (pid_to_attach < 0 ) {
+				if (ptrace(PTRACE_TRACEME, 0, (char *) 1, 0) < 0) {
+					perror("strace: ptrace(PTRACE_TRACEME, ...)");
+					exit(1);
+				}
+			} else {
+				if (ptrace(PTRACE_ATTACH, pid_to_attach, (char *) 1, 0) < 0) {
+					perror("strace: ptrace(PTRACE_ATTACH, ...)");
+					exit(1);
+				}
 			}
 			if (debug)
 				kill(pid, SIGSTOP);
@@ -704,8 +714,11 @@ startup_child (char **argv, int pid_to_attach)
 			 * Unless of course we're on a no-MMU system where
 			 * we vfork()-ed, so we cannot stop the child.
 			 */
-			if (!strace_vforked)
+			if (pid_to_attach > 0) {
+				kill(pid_to_attach, SIGSTOP);
+			} else if (!strace_vforked) {
 				kill(getpid(), SIGSTOP);
+			}
 		} else {
 			struct sigaction sv_sigchld;
 			sigaction(SIGCHLD, NULL, &sv_sigchld);
@@ -740,10 +753,12 @@ startup_child (char **argv, int pid_to_attach)
       }
     }
 
-		execvp(pathname, argv);
-fprintf(stderr, "%s %d\n", pathname, cde_exec_from_outside_cderoot);
-		perror("strace: exec");
-		_exit(1);
+		if (pid_to_attach < 0) {
+			execvp(pathname, argv);
+			fprintf(stderr, "%s %d\n", pathname, cde_exec_from_outside_cderoot);
+			perror("strace: exec");
+			_exit(1);
+		}
 	}
 
 	/* We are the tracer.  */
@@ -2925,6 +2940,13 @@ int main (int argc, char *argv[]) {
 		exit(1);
 	}
 
+	if (pid_to_attach > 0 && daemonized_tracer) {
+		fprintf(stderr,
+			"%s: -D and -A are mutually exclusive options\n",
+			progname);
+		exit(1);
+	}
+
 	if (!followfork)
 		followfork = optF;
 
@@ -3105,7 +3127,7 @@ int main (int argc, char *argv[]) {
 	sigaction(SIGCHLD, &sa, NULL);
 #endif /* USE_PROCFS */
 
-	if (pflag_seen || daemonized_tracer)
+	if (pflag_seen || daemonized_tracer || pid_to_attach > 0)
 		startup_attach();
 
 	if (trace() < 0)

--- a/strace-4.6/strace.c
+++ b/strace-4.6/strace.c
@@ -129,7 +129,9 @@ unsigned int ptrace_setoptions = 0;
 int dtime = 0, xflag = 0, qflag = 1; // pgbovine - turn on quiet mode (-q) by
                                      // default to shut up terminal line noise
 cflag_t cflag = CFLAG_NONE;
-static int iflag = 0, interactive = 0, pflag_seen = 0, rflag = 0, tflag = 0, pid_to_attach = -1, stop_tracing_from_signal = 0;
+static int iflag = 0, interactive = 0, pflag_seen = 0, rflag = 0, tflag = 0;
+static int pid_to_attach = -1, pid_to_attach_signal = -1, stop_tracing_from_signal = 0;
+
 /*
  * daemonized_tracer supports -D option.
  * With this option, strace forks twice.
@@ -527,8 +529,10 @@ startup_attach(void)
 				tcp->pid);
 	}
 
-	if (interactive)
+	if (interactive) {
 		sigprocmask(SIG_SETMASK, &empty_set, NULL);
+	}
+
 }
 
 static void
@@ -2895,7 +2899,7 @@ int main (int argc, char *argv[]) {
 			/*CDE_network_content_mode = 1;*/
 			break;
 		case 'A':
-			pid_to_attach = atoi(optarg);
+			sscanf(optarg, "%d,%d", &pid_to_attach, &pid_to_attach_signal);
 			break;
 		default:
 			usage(stderr, 1);
@@ -3129,6 +3133,11 @@ int main (int argc, char *argv[]) {
 
 	if (pflag_seen || daemonized_tracer || pid_to_attach > 0)
 		startup_attach();
+
+	if (pid_to_attach > 0 && pid_to_attach_signal > -1) {
+		/* send requested signal to external pid */
+		kill(pid_to_attach, pid_to_attach_signal);
+	}
 
 	if (trace() < 0)
 		exit(1);


### PR DESCRIPTION
Adds the `-A PID` command line option that allows ptu to attach to a running process. ptu exits when the targeted process exits.